### PR TITLE
Avoid repeated creation of Eups object

### DIFF
--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -216,7 +216,7 @@ def ProductDir(env, product):
         _productDirs
     except:
         try:
-            _productDirs = eupsForScons.productDir()
+            _productDirs = eupsForScons.productDir(eupsenv=eupsForScons.getEups())
         except TypeError:               # old version of eups (pre r18588)
             _productDirs = None
     if _productDirs:

--- a/python/lsst/sconsUtils/dependencies.py
+++ b/python/lsst/sconsUtils/dependencies.py
@@ -117,7 +117,7 @@ class Configuration(object):
 
     @staticmethod
     def getEupsData(eupsProduct):
-        version, eupsPathDir, productDir, table, flavor = eupsForScons.Eups().findSetupVersion(eupsProduct)
+        version, eupsPathDir, productDir, table, flavor = eupsForScons.getEups().findSetupVersion(eupsProduct)
         if productDir is None:
             productDir = eupsForScons.productDir(eupsProduct)
         return version, productDir    

--- a/python/lsst/sconsUtils/eupsForScons.py
+++ b/python/lsst/sconsUtils/eupsForScons.py
@@ -38,3 +38,10 @@ except ImportError:
     
     utils.setupEnvNameFor = setupEnvNameFor
 
+def getEups():
+    """ Return a cached Eups instance, auto-creating if necessary """
+    try:
+        return getEups._eups
+    except AttributeError:
+        getEups._eups = Eups()
+        return getEups._eups


### PR DESCRIPTION
On creation, the current implementation of Eups class loads the entire product stack database, which can take a long time on systems where the stack has thousands of products.
