### PR TITLE
Add -headerpad_max_install_names to linker flags on OS X

### DIFF
--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -21,7 +21,7 @@ from . import state
 def SharedLibraryIncomplete(self, target, source, **keywords):
     myenv = self.Clone()
     if myenv['PLATFORM'] == 'darwin':
-        myenv['SHLINKFLAGS'] += ["-undefined", "suppress", "-flat_namespace"]
+        myenv['SHLINKFLAGS'] += ["-undefined", "suppress", "-flat_namespace", "-headerpad_max_install_names"]
     return myenv.SharedLibrary(target, source, **keywords)
 
 ##  @brief Like LoadableModule, but don't insist that all symbols are resolved, and set
@@ -30,7 +30,7 @@ def SharedLibraryIncomplete(self, target, source, **keywords):
 def SwigLoadableModule(self, target, source, **keywords):
     myenv = self.Clone()
     if myenv['PLATFORM'] == 'darwin':
-        myenv.Append(LDMODULEFLAGS = ["-undefined", "suppress", "-flat_namespace",])
+        myenv.Append(LDMODULEFLAGS = ["-undefined", "suppress", "-flat_namespace", "-headerpad_max_install_names"])
     #
     # Swig-generated .cc files cast pointers to long longs and back,
     # which is illegal.  This flag tells g++ about the sin

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -160,6 +160,8 @@ def _initEnvironment():
         env['LDMODULESUFFIX'] = ".so"
         if not re.search(r"-install_name", str(env['SHLINKFLAGS'])):
             env.Append(SHLINKFLAGS = ["-Wl,-install_name", "-Wl,${TARGET.file}"])
+        if not re.search(r"-headerpad_max_install_names", str(env['SHLINKFLAGS'])):
+            env.Append(SHLINKFLAGS = ["-Wl,-headerpad_max_install_names"])
     #
     # Remove valid options from the arguments
     #

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -287,8 +287,8 @@ def _configureCommon():
     #
     ARCHFLAGS = os.environ.get("ARCHFLAGS", env.get('archflags'))
     if ARCHFLAGS:
-        env.Append(CCFLAGS = [ARCHFLAGS.split()])
-        env.Append(LINKFLAGS = [ARCHFLAGS.split()])
+        env.Append(CCFLAGS = ARCHFLAGS.split())
+        env.Append(LINKFLAGS = ARCHFLAGS.split())
     # We'll add warning and optimisation options last
     if env['profile'] == '1' or env['profile'] == "pg":
         env.Append(CCFLAGS = ['-pg'])


### PR DESCRIPTION
This makes it possible for install_name_tool to reliably modify RPATH names
after builds (to make the code relocatable).

Ref.: https://annoyingtechnicaldetails.wordpress.com/2007/04/18/install_name_tool-changing-install-names-cant-be-redone-for-for-architecture-ppc-because-larger-updated-load-commands-do-not-fit-the-program-must-be-relinked/