### PR TITLE
recognise gcc with appended version

### DIFF
--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -236,7 +236,7 @@ def _configureCommon():
         @return (compiler, version) as a pair of strings, or ("unknown", "unknown") if unknown
         """
         versionNameList = (
-            (r"gcc +\(.+\) +([0-9.a-zA-Z]+)", "gcc"),
+            (r"gcc(?:\-.+)? +\(.+\) +([0-9.a-zA-Z]+)", "gcc"),
             (r"LLVM +version +([0-9.a-zA-Z]+) ", "clang"), # clang on Mac
             (r"clang +version +([0-9.a-zA-Z]+) ", "clang"), # clang on linux
             (r"\(ICC\) +([0-9.a-zA-Z]+) ", "icc"),


### PR DESCRIPTION
$CC may be something like "gcc-4.8", which needs to be recognised as gcc.
Note also that "gcc-4.8 --version" produces something like:

    gcc-4.8 (Homebrew gcc48 4.8.4) 4.8.4

so we have to deal with that additional "-4.8".