### PR TITLE
Move code that handles LSST_LIBRARY_PATH from tests to utils

### DIFF
--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -161,16 +161,9 @@ class Control(object):
 
             (should_pass, passedMsg, should_fail, failedMsg) = self.messages(f)
 
-            libpathstr = ""
-
-            # If we have an OS X with System Integrity Protection enabled or similar we need
-            # to pass through DYLD_LIBRARY_PATH to the test execution layer.
-            pass_through_var = utils.libraryPathPassThrough()
-            if pass_through_var is not None:
-                for varname in (pass_through_var, "LSST_LIBRARY_PATH"):
-                    if varname in os.environ:
-                        libpathstr = '{}="{}"'.format(pass_through_var, os.environ[varname])
-                        break
+            # Determine any library load path values that we have to prepend
+            # to the command.
+            libpathstr = utils.libraryLoaderEnvironment()
 
             # The TRAVIS environment variable is set to allow us to disable
             # the matplotlib font cache. See ticket DM-3856.

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -5,6 +5,7 @@
 ##
 
 from __future__ import absolute_import, division, print_function
+import os
 import sys
 import warnings
 import subprocess
@@ -78,6 +79,21 @@ def libraryPathPassThrough():
 def needShebangRewrite():
     return _has_OSX_SIP()
 
+##
+#  @brief Returns library loader path environment string to be prepended to external commands
+#         Will be "" if nothing is required.
+##
+def libraryLoaderEnvironment():
+    libpathstr = ""
+    # If we have an OS X with System Integrity Protection enabled or similar we need
+    # to pass through DYLD_LIBRARY_PATH to the external command.
+    pass_through_var = libraryPathPassThrough()
+    if pass_through_var is not None:
+        for varname in (pass_through_var, "LSST_LIBRARY_PATH"):
+            if varname in os.environ:
+                libpathstr = '{}="{}"'.format(pass_through_var, os.environ[varname])
+                break
+    return libpathstr
 
 ##
 #  @brief Safe wrapper for running external programs, reading stdout, and sanitizing error messages.


### PR DESCRIPTION
This allows the logic to be reused by other components that
are trying to launch commands.