### PR TITLE
DM-4900 Add XML as a doxygen output

### DIFF
--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -457,7 +457,7 @@ def Doxygen(self, config, **kw):
         "inputs": inputs,
         "recursive": True,
         "patterns": ["*.h", "*.cc", "*.py", "*.dox"],
-        "outputs": ["html"],
+        "outputs": ["html", "xml"],
         "excludes": [],
         "includes": [],
         "useTags": [],


### PR DESCRIPTION
For the new documentation, Breathe will bridge Doxygen's C++ API
reference docs to Sphinx. Breathe uses XML as its input.

HTML output is currently retained for backwards compatibility with the
existing documentation infrastructure.

For DM-4900.