### PR TITLE
add macosx_deployment_target flag

### DIFF
--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -106,6 +106,7 @@ def _initVariables():
         ('baseversion', 'Specify the current base version', None),
         ('optFiles', "Specify a list of files that SHOULD be optimized", None),
         ('noOptFiles', "Specify a list of files that should NOT be optimized", None),
+        ('macosx_deployment_target', 'Deployment target for Mac OS X', '10.9'),
         )
 
 
@@ -174,6 +175,12 @@ def _initEnvironment():
             env.Append(SHLINKFLAGS=["-Wl,-install_name", "-Wl,${TARGET.file}"])
         if not re.search(r"-headerpad_max_install_names", str(env['SHLINKFLAGS'])):
             env.Append(SHLINKFLAGS=["-Wl,-headerpad_max_install_names"])
+        #
+        # We want to be explicit about the OS X version we're targeting
+        #
+        env['ENV']['MACOSX_DEPLOYMENT_TARGET'] = env['macosx_deployment_target']
+        log.info("Setting OS X binary compatibility level: %s" % env['ENV']['MACOSX_DEPLOYMENT_TARGET'])
+
     #
     # Remove valid options from the arguments
     #


### PR DESCRIPTION
Adds the ability to set the `MACOSX_DEPLOYMENT_TARGET`, which affects
ABI compatibility on OSX.