### PR TITLE
Ask python on path where it is located

### DIFF
--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -9,7 +9,6 @@
 from __future__ import absolute_import, division, print_function
 import os.path
 import re
-import sys
 import pipes
 from stat import ST_MODE
 from SCons.Script import SConscript, File, Dir, Glob, BUILD_TARGETS
@@ -243,7 +242,7 @@ class BasicSConscript(object):
         def rewrite_shebang(target, source, env):
             """Copy source to target, rewriting the shebang"""
             # Currently just use this python
-            usepython = sys.executable
+            usepython = utils.whichPython()
             for targ, src in zip(target, source):
                 with open(str(src), "r") as srcfd:
                     with open(str(targ), "w") as outfd:

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -73,6 +73,24 @@ def libraryPathPassThrough():
     return None
 
 
+# Cache variable for whichPython() function
+_pythonPath = None
+
+
+##
+#  @brief Returns the full path to the Python executable as determined
+#  from the PATH. Does not return the full path of the Python running
+#  SCons. Caches result and assumes the PATH does not change between
+#  calls. Runs the "python" command and asks where it is rather than
+#  scanning the PATH.
+def whichPython():
+    global _pythonPath
+    if _pythonPath is None:
+        output = subprocess.check_output(["python", "-c", "import sys; print(sys.executable)"])
+        _pythonPath = output.decode()
+    return _pythonPath
+
+
 ##
 #  @brief Returns True if the shebang lines of executables should be rewritten
 ##


### PR DESCRIPTION
Do not ask the Python running SCons for its sys.executable.

This is needed when we do not know if the SCons python is the
same python we wish to use to run the applications built by
SCons.