### PR TITLE
Stop xdist restarting workers if they won't start

### DIFF
--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -237,7 +237,7 @@ class Control(object):
         njobs = self._env.GetOption("num_jobs")
         print("Running pytest with {} process{}".format(njobs, "" if njobs == 1 else "es"))
         if njobs > 1:
-            interpreter = interpreter + " -n {}".format(njobs)
+            interpreter = interpreter + " --max-slave-restart=0 -n {}".format(njobs)
 
         # Remove target so that we always trigger pytest
         if os.path.exists(target):


### PR DESCRIPTION
This is mostly because of a problem with SEGV on import in C++ code which will never work. Without this xdist keeps creating workers until the process runs out of resources.