### PR TITLE
Do not force worker python executable if space is in path

### DIFF
--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -247,8 +247,17 @@ class Control(object):
             # with site-packages directories corresponding to both locations
             # on ``sys.path``, even if the one is a symlink to the other).
             executable = os.path.realpath(sys.executable)
-            interpreter = (interpreter +
-                           " -d --max-slave-restart=0 --tx={}*popen//python={}".format(njobs, executable))
+
+            # if there is a space in the executable path we have to use the original
+            # method and hope things work okay. This will be rare but without
+            # this a space in the path is impossible because of how xdist
+            # currently parses the tx option
+            interpreter = interpreter + " --max-slave-restart=0"
+            if " " not in executable:
+                interpreter = (interpreter +
+                               " -d --tx={}*popen//python={}".format(njobs, executable))
+            else:
+                interpreter = interpreter + "  -n {}".format(njobs)
 
         # Remove target so that we always trigger pytest
         if os.path.exists(target):


### PR DESCRIPTION
xdist does not handle a space in the path when parsing the command line option, so for now we fall back to the original scheme of not specifying it at all if the path is not compatible.