### PR TITLE
DM-13910: make compiler check fire only when needed

### DIFF
--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -60,9 +60,10 @@ class BasicSConstruct(object):
                 defaultTargets=DEFAULT_TARGETS,
                 subDirList=None, ignoreRegex=None,
                 versionModuleName="python/lsst/%s/version.py", noCfgFile=False,
-                sconscriptOrder=None):
+                sconscriptOrder=None, disableCc=False):
         cls.initialize(packageName, versionString, eupsProduct, eupsProductPath, cleanExt,
-                       versionModuleName, noCfgFile=noCfgFile, sconscriptOrder=sconscriptOrder)
+                       versionModuleName, noCfgFile=noCfgFile, sconscriptOrder=sconscriptOrder,
+                       disableCc=disableCc)
         cls.finish(defaultTargets, subDirList, ignoreRegex)
         return state.env
 
@@ -93,13 +94,19 @@ class BasicSConstruct(object):
     #                              ordering for the lib, python, tests, examples, and doc targets.  If this
     #                              argument is provided, it must include the subset of that list that is valid
     #                              for the package, in that order.
+    # @param disableCC             Should the C++ compiler check be disabled? Disabling this check allows
+    #                              a faster startup and permits building on systems that don't meet the
+    #                              requirements for the C++ compilter (e.g., for pure-python packages).
     #
     #  @returns an SCons Environment object (which is also available as lsst.sconsUtils.env).
     ##
     @classmethod
     def initialize(cls, packageName, versionString=None, eupsProduct=None, eupsProductPath=None,
                    cleanExt=None, versionModuleName="python/lsst/%s/version.py", noCfgFile=False,
-                   sconscriptOrder=None):
+                   sconscriptOrder=None, disableCc=False):
+        if not disableCc:
+            state._configureCommon()
+            state._saveState()
         if cls._initializing:
             state.log.fail("Recursion detected; an SConscript file should not call BasicSConstruct.")
         cls._initializing = True

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -284,8 +284,16 @@ def _initEnvironment():
     env['eupsFlavor'] = eupsForScons.flavor()
 
 
+_configured = False
+
+
 def _configureCommon():
     """Configuration checks for the compiler, platform, and standard libraries."""
+    global _configured
+    if _configured:
+        return
+    _configured = True
+
     #
     # Is the C compiler really gcc/g++?
     #
@@ -503,7 +511,5 @@ _initOptions()
 _initLog()
 _initVariables()
 _initEnvironment()
-_configureCommon()
-_saveState()
 
 # @endcond


### PR DESCRIPTION
The compiler check in lsst.sconsUtils.state._configureCommon
fires whenever you import lsst.sconsUtils, even if you don't
have any C++ code and all you want out of lsst.sconsUtils is
some utility completely unrelated to C++. Besides just wasting
time, this makes it difficult to run ci_hsc on a cluster nodes
that don't have the latest gcc installed.

Instead, have the compiler check only fire when we need it, as
defined by instantiating BasicSConstruct. The compiler check
can also be disabled when using BasicSConstruct by instantiating
it with disableCc=True.