### PR TITLE
DM-11693: Prevent double running of tests during build install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache
+.pytest_cache
 .sconsign.dblite
 config.log
 .sconf_temp

--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -7,7 +7,7 @@ import glob
 import os
 import sys
 import pipes
-from SCons.Script import *  # noqa F403 F401 So that this file has the same namespace as SConstruct/SConscript
+import SCons.Script
 from . import state
 from . import utils
 
@@ -235,7 +235,7 @@ class Control:
         # We always want to run this with the tests target.
         # We have decided to use pytest caching so that on reruns we only
         # run failed tests.
-        lfnfOpt = "none" if 'install' in COMMAND_LINE_TARGETS else "all"
+        lfnfOpt = "none" if 'install' in SCons.Script.COMMAND_LINE_TARGETS else "all"
         interpreter = f"pytest -Wd --lf --lfnf={lfnfOpt}"
         interpreter += " --junit-xml=${TARGET} --session2file=${TARGET}.out"
         interpreter += " --junit-prefix={0}".format(self.junitPrefix())

--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -235,7 +235,9 @@ class Control:
         # We always want to run this with the tests target.
         # We have decided to use pytest caching so that on reruns we only
         # run failed tests.
-        interpreter = "pytest -Wd --lf --junit-xml=${TARGET} --session2file=${TARGET}.out"
+        lfnfOpt = "none" if 'install' in COMMAND_LINE_TARGETS else "all"
+        interpreter = f"pytest -Wd --lf --lfnf={lfnfOpt}"
+        interpreter += " --junit-xml=${TARGET} --session2file=${TARGET}.out"
         interpreter += " --junit-prefix={0}".format(self.junitPrefix())
         interpreter += self._getPytestCoverageCommand()
 

--- a/ups/sconsUtils.table
+++ b/ups/sconsUtils.table
@@ -1,6 +1,7 @@
 setupRequired(scons)
 setupRequired(pytest)
 setupRequired(pytest_flake8)
+setupRequired(pep8_naming)
 setupRequired(pytest_xdist)
 setupRequired(pytest_session2file)
 setupRequired(pytest_cov)


### PR DESCRIPTION
This fix prevents a full duplicate pytest execution during the install phase.

Pytest's session is aware of what tests ran, and by default, it will try to rerun all tests. This PR well set the `--last-failed-no-failures` behavior based on the scons goal. If it's `install`, it will tell pytest to skip running tests, though pytest will still run to determine if tests may have changed in that time frame.

After the first pytest runs successfully, we store the test outputs.
If no tests run (pytest will exit with code 5), we re-stage the original results, as pytest will still write output if no tests run.