### PR TITLE
DM-15790: Compile pybind11 with hidden symbol visibility on linux

### DIFF
--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -51,10 +51,10 @@ def SwigLoadableModule(self, target, source, **keywords):
 @memberOf(SConsEnvironment)
 def Pybind11LoadableModule(self, target, source, **keywords):
     myenv = self.Clone()
+    myenv.Append(CCFLAGS=["-fvisibility=hidden"])
     if myenv['PLATFORM'] == 'darwin':
         myenv.Append(LDMODULEFLAGS=["-undefined", "suppress",
                                     "-flat_namespace", "-headerpad_max_install_names"])
-        myenv.Append(CCFLAGS=["-fvisibility=hidden"])
     return myenv.LoadableModule(target, source, **keywords)
 
 # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-


### PR DESCRIPTION
as well as macOS