### PR TITLE
DM-15851: Clean target files if we are not performing an install

### DIFF
--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -284,7 +284,10 @@ class Control:
         # If we ran all the test, then copy the previous test
         # execution products to `.all' files so we can retrieve later.
         # If we skip the test (exit code 5), retrieve those `.all' files.
-        cmd = """
+        cmd = ""
+        if lfnfOpt == "all":
+            cmd += "@rm -f ${{TARGET}} ${{TARGET}}.failed;"
+        cmd += """
         @printf "%s\\n" 'running global pytest... ';
         @({2} TRAVIS=1 {0} {1}); \
         export rc="$?"; \

--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -286,7 +286,7 @@ class Control:
         # If we skip the test (exit code 5), retrieve those `.all' files.
         cmd = ""
         if lfnfOpt == "all":
-            cmd += "@rm -f ${{TARGET}} ${{TARGET}}.failed;"
+            cmd += "@rm -f ${{TARGET}} ${{TARGET}}.failed; \\"
         cmd += """
         @printf "%s\\n" 'running global pytest... ';
         @({2} TRAVIS=1 {0} {1}); \


### PR DESCRIPTION
If we are supplying the `--last-failed-no-failures` flag (`lfnfOpt`) with the value of `all`, then make sure to delete the previous target files before executing the SCons command. 

If we are invoking SCons for an install, we set the `lfnfOpt = "none"`, otherwise it's all.
