### PR TITLE
DM-15851 Hotfix: Don't try to escape newline if prepending command

### DIFF
--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -286,7 +286,7 @@ class Control:
         # If we skip the test (exit code 5), retrieve those `.all' files.
         cmd = ""
         if lfnfOpt == "all":
-            cmd += "@rm -f ${{TARGET}} ${{TARGET}}.failed; \\"
+            cmd += "@rm -f ${{TARGET}} ${{TARGET}}.failed;"
         cmd += """
         @printf "%s\\n" 'running global pytest... ';
         @({2} TRAVIS=1 {0} {1}); \


### PR DESCRIPTION
The escaped newline backslash was causing a problem in ubuntu 18.04.