### PR TITLE
DM-16220: Use subprocess.run for all external commands

### DIFF
--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -155,14 +155,14 @@ def runExternal(cmd, fatal=False, msg=None):
 
     try:
         retval = subprocess.run(cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                check=True, text=True)
+                                check=True)
     except subprocess.CalledProcessError as e:
         if fatal:
-            raise RuntimeError(f"{msg}: {e.stderr}") from e
+            raise RuntimeError(f"{msg}: {e.stderr.decode()}") from e
         else:
             from . import state  # can't import at module scope due to circular dependency
             state.log.warn(f"{msg}: {e.stderr}")
-    return retval.stdout.strip()
+    return retval.stdout.decode().strip()
 
 
 ##

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -154,7 +154,8 @@ def runExternal(cmd, fatal=False, msg=None):
         shell = False
 
     try:
-        retval = subprocess.run(cmd, capture_output=True, shell=shell, check=True, text=True)
+        retval = subprocess.run(cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                check=True, text=True)
     except subprocess.CalledProcessError as e:
         if fatal:
             raise RuntimeError(f"{msg}: {e.stderr}") from e


### PR DESCRIPTION
Standardize on the modern way for running external commands.