### PR TITLE
allow color outputs from compilers

### DIFF
--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -123,6 +123,7 @@ def _initEnvironment():
       PATH
       SHELL
       TEMP
+      TERM
       TMP
       TMPDIR
       XPA_PORT


### PR DESCRIPTION
by propagating the TERM envvar through scons, as proposed:
    https://stackoverflow.com/a/9954572

This should not affect the compilation of anything, but only
the format of the outputs.