### PR TITLE
DM-21286: Set XDG_CACHE_HOME for use by Astropy

### DIFF
--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -5,6 +5,7 @@ There is nothing scons-specific about these tests.
 """
 
 import unittest
+import os
 
 
 class SimplestPossibleTestCase(unittest.TestCase):
@@ -12,6 +13,13 @@ class SimplestPossibleTestCase(unittest.TestCase):
 
     def testSimple(self):
         self.assertEqual(2 + 2, 4)
+
+    def testEnvironment(self):
+        """Test the environment. The test will fail if the tests are run
+        by anything other than SCons."""
+        envVar = "XDG_CACHE_HOME"
+        self.assertIn(envVar, os.environ)
+        self.assertTrue(os.path.exists(os.environ[envVar]), f"Check path {os.environ[envVar]}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Astropy needs to be able to find its cache files