### PR TITLE
DM-23835: Support conda compilers and conda third parties

### DIFF
--- a/configs/apr.cfg
+++ b/configs/apr.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": [],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["apr-1/apr.h"],
+    libs=["apr-1"],
+)

--- a/configs/apr_util.cfg
+++ b/configs/apr_util.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["apr"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=[],
+    libs=["aprutil-1", "iconv"],
+)

--- a/configs/boost.cfg
+++ b/configs/boost.cfg
@@ -1,0 +1,12 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/version.hpp"],
+    libs=["pthread"],
+    eupsProduct="boost"
+)

--- a/configs/boost_filesystem.cfg
+++ b/configs/boost_filesystem.cfg
@@ -1,0 +1,15 @@
+
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost", "boost_system"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/filesystem.hpp"],
+    libs=["boost_filesystem"],
+    eupsProduct="boost",
+)

--- a/configs/boost_math.cfg
+++ b/configs/boost_math.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/math/tr1.hpp"],
+    libs=["boost_math_c99"],
+    eupsProduct="boost",
+)

--- a/configs/boost_program_options.cfg
+++ b/configs/boost_program_options.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/program_options.hpp"],
+    libs=["boost_program_options"],
+    eupsProduct="boost",
+)

--- a/configs/boost_regex.cfg
+++ b/configs/boost_regex.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/regex.hpp"],
+    libs=["boost_regex"],
+    eupsProduct="boost",
+)

--- a/configs/boost_serialization.cfg
+++ b/configs/boost_serialization.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/serialization/serialization.hpp"],
+    libs=["boost_serialization"],
+    eupsProduct="boost",
+)

--- a/configs/boost_system.cfg
+++ b/configs/boost_system.cfg
@@ -1,0 +1,15 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/system/config.hpp"],
+    libs=["boost_system"],
+    eupsProduct="boost",
+)
+

--- a/configs/boost_test.cfg
+++ b/configs/boost_test.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/test/unit_test.hpp"],
+    libs={"main": [], "test": ["boost_unit_test_framework"]},
+    eupsProduct="boost",
+)

--- a/configs/boost_thread.cfg
+++ b/configs/boost_thread.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost", "boost_system"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/thread.hpp"],
+    libs=["boost_thread"],
+    eupsProduct="boost",
+)

--- a/configs/cfitsio.cfg
+++ b/configs/cfitsio.cfg
@@ -1,0 +1,18 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": [],
+}
+
+class Configuration(lsst.sconsUtils.ExternalConfiguration):
+
+    def configure(self, conf, packages, check=False, build=True):
+        lsst.sconsUtils.ExternalConfiguration.configure(self, conf, packages, check)
+        if check:
+            return conf.checkLib("cfitsio", "ffopen", "fitsio.h", language="C", autoadd=False)
+        conf.env.libs["main"].append("cfitsio")
+        return True
+
+config = Configuration(__file__)

--- a/configs/eigen.cfg
+++ b/configs/eigen.cfg
@@ -1,0 +1,24 @@
+# -*- python -*-
+
+import os
+import lsst.sconsUtils
+from lsst.sconsUtils import ExternalConfiguration
+
+dependencies = {
+    "required": [],
+}
+
+class EigenConfiguration(ExternalConfiguration):
+
+    def configure(self, conf, packages, check=False, build=True):
+        configured = ExternalConfiguration.configure(self, conf, packages, check, build)
+        # We add this to support minuit2_standalone, which puts headers under Minuit2
+        includePath = os.path.join(self._get_config_var("CONFINCLUDEPY"), "../eigen3")
+        conf.env.AppendUnique(XCPPPATH=includePath)
+        return configured
+
+config = EigenConfiguration(
+    __file__,
+    headers=["Eigen/Core"],
+    libs=["eigen"],
+)

--- a/configs/eigen.cfg
+++ b/configs/eigen.cfg
@@ -3,6 +3,7 @@
 import os
 import lsst.sconsUtils
 from lsst.sconsUtils import ExternalConfiguration
+from lsst.sconsUtils.utils import use_conda_compilers, get_conda_prefix
 
 dependencies = {
     "required": [],
@@ -12,13 +13,14 @@ class EigenConfiguration(ExternalConfiguration):
 
     def configure(self, conf, packages, check=False, build=True):
         configured = ExternalConfiguration.configure(self, conf, packages, check, build)
-        # We add this to support minuit2_standalone, which puts headers under Minuit2
-        includePath = os.path.join(self._get_config_var("CONFINCLUDEPY"), "../eigen3")
+        if use_conda_compilers():
+            # Support header namespaces in conda-forge
+            includePath = os.path.join(get_conda_prefix(), "include/eigen3")
         conf.env.AppendUnique(XCPPPATH=includePath)
         return configured
 
 config = EigenConfiguration(
     __file__,
     headers=["Eigen/Core"],
-    libs=["eigen"],
+    libs=[],
 )

--- a/configs/fftw.cfg
+++ b/configs/fftw.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": [],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["fftw3.h"],
+    libs=["fftw3","fftw3f"],
+)

--- a/configs/galsim.cfg
+++ b/configs/galsim.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["numpy", "fftw", "eigen"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["GalSim.h"],
+    libs=["galsim"],
+)

--- a/configs/gsl.cfg
+++ b/configs/gsl.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": [],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["gsl/gsl_rng.h"],
+    libs=["gslcblas", "gsl"],
+)

--- a/configs/log4cxx.cfg
+++ b/configs/log4cxx.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": [],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["log4cxx/logger.h"],
+    libs=["log4cxx"],
+)

--- a/configs/minuit2.cfg
+++ b/configs/minuit2.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": [],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["Minuit2/FCNBase.h"],
+    libs=["Minuit2"],
+)

--- a/configs/minuit2.cfg
+++ b/configs/minuit2.cfg
@@ -1,13 +1,24 @@
 # -*- python -*-
 
 import lsst.sconsUtils
+from lsst.sconsUtils import ExternalConfiguration
+import os
 
 dependencies = {
     "required": [],
 }
 
-config = lsst.sconsUtils.ExternalConfiguration(
+class Minuit2Configuration(ExternalConfiguration):
+
+    def configure(self, conf, packages, check=False, build=True):
+        configured = ExternalConfiguration.configure(self, conf, packages, check, build)
+        # We add this to support minuit2_standalone, which puts headers under Minuit2
+        includePath = os.path.join(self._get_config_var("CONFINCLUDEPY"), "../Minuit2")
+        conf.env.AppendUnique(XCPPPATH=includePath)
+        return configured
+
+config = Minuit2Configuration(
     __file__,
-    headers=["Minuit2/Minuit2/FCNBase.h"], # For minuit2_standalone only
+    headers=["Minuit2/FCNBase.h"],
     libs=["Minuit2"],
 )

--- a/configs/minuit2.cfg
+++ b/configs/minuit2.cfg
@@ -8,6 +8,6 @@ dependencies = {
 
 config = lsst.sconsUtils.ExternalConfiguration(
     __file__,
-    headers=["Minuit2/FCNBase.h"],
+    headers=["Minuit2/Minuit2/FCNBase.h"], # For minuit2_standalone only
     libs=["Minuit2"],
 )

--- a/configs/minuit2.cfg
+++ b/configs/minuit2.cfg
@@ -8,6 +8,6 @@ dependencies = {
 
 config = lsst.sconsUtils.ExternalConfiguration(
     __file__,
-    headers=["Minuit2/Minuit2/FCNBase.h"], # For minuit2_standalone only
+    headers=["Minuit2/FCNBase.h"],
     libs=["Minuit2"],
 )

--- a/configs/minuit2.cfg
+++ b/configs/minuit2.cfg
@@ -2,6 +2,7 @@
 
 import lsst.sconsUtils
 from lsst.sconsUtils import ExternalConfiguration
+from lsst.sconsUtils.utils import use_conda_compilers, get_conda_prefix
 import os
 
 dependencies = {
@@ -12,9 +13,10 @@ class Minuit2Configuration(ExternalConfiguration):
 
     def configure(self, conf, packages, check=False, build=True):
         configured = ExternalConfiguration.configure(self, conf, packages, check, build)
-        # We add this to support minuit2_standalone, which puts headers under Minuit2
-        includePath = os.path.join(self._get_config_var("CONFINCLUDEPY"), "../Minuit2")
-        conf.env.AppendUnique(XCPPPATH=includePath)
+        if use_conda_compilers():
+            # Support header namespaces in conda-forge
+            includePath = os.path.join(get_conda_prefix(), "include/Minuit2")
+            conf.env.AppendUnique(XCPPPATH=includePath)
         return configured
 
 config = Minuit2Configuration(

--- a/configs/ndarray.cfg
+++ b/configs/ndarray.cfg
@@ -1,0 +1,17 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost", "numpy", "fftw"],
+    "buildRequired": ["boost_test", "pybind11"],
+}
+
+config = lsst.sconsUtils.Configuration(
+    __file__,
+    headers=["lsst/ndarray.h"],
+    libs=[],
+    hasDoxygenInclude=False,
+    hasDoxygenTag=False,
+    hasSwigFiles=False
+)

--- a/configs/ndarray.cfg
+++ b/configs/ndarray.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["boost", "numpy", "fftw"],
+    "required": ["boost", "numpy", "fftw", "eigen"],
     "buildRequired": ["boost_test", "pybind11"],
 }
 

--- a/configs/numpy.cfg
+++ b/configs/numpy.cfg
@@ -1,0 +1,31 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+import subprocess
+
+dependencies = {}
+
+
+class Configuration(lsst.sconsUtils.Configuration):
+
+    def __init__(self):
+        self.name, self.root = self.parseFilename(__file__)
+        try:
+            version, productDir = self.getEupsData(self.name)
+            self.version = version
+        except:
+            pass
+
+    def configure(self, conf, packages, check=False, build=True):
+        lsst.sconsUtils.log.info("Configuring package '%s'." % self.name)
+        try:
+            # Returns the path to a single include directory
+            output = subprocess.check_output(["python", "-c",
+                                              "import numpy; print(numpy.get_include())"]).decode()
+            output = output.strip()
+        except subprocess.CalledProcessError:
+            return False
+        conf.env.AppendUnique(XCPPPATH=[output])
+        return True
+
+config = Configuration()

--- a/configs/pybind11.cfg
+++ b/configs/pybind11.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["python"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["pybind11/pybind11.h"],
+    libs=[],
+)

--- a/configs/python.cfg
+++ b/configs/python.cfg
@@ -1,0 +1,68 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+import re
+import os.path
+import subprocess
+
+dependencies = {}
+
+class Configuration(lsst.sconsUtils.Configuration):
+
+    def __init__(self):
+        self.name, self.root = self.parseFilename(__file__)
+
+    @staticmethod
+    def _get_config_var(name):
+        """The relevant Python is not guaranteed to be the Python
+        that we are using to run SCons so we must shell out to the
+        PATH python."""
+        pycmd = 'import distutils.sysconfig as s; print(s.get_config_var("{}"))'.format(name)
+        result = subprocess.check_output(["python", "-c", pycmd]).decode().strip()
+        # Be consistent with native interface
+        if result == "None":
+            result = None
+        return result
+
+    def configure(self, conf, packages, check=False, build=True):
+        lsst.sconsUtils.log.info("Configuring package '%s'." % self.name)
+        conf.env.AppendUnique(XCPPPATH=self._get_config_var("CONFINCLUDEPY").split())
+        libDir = self._get_config_var("LIBPL")
+        conf.env.AppendUnique(LIBPATH=[libDir])
+        pylibrary = self._get_config_var("LIBRARY")
+        mat = re.search("(python.*)\.(a|so|dylib)$", pylibrary)
+        if mat:
+            conf.env.libs["python"].append(mat.group(1))
+            lsst.sconsUtils.log.info("Adding '%s' to target 'python'." % mat.group(1))
+        for w in (" ".join([self._get_config_var("MODLIBS"),
+                            self._get_config_var("SHLIBS")])).split():
+            mat = re.search(r"^-([Ll])(.*)", w)
+            if mat:
+                lL = mat.group(1)
+                arg = mat.group(2)
+                if lL == "l":
+                    if not arg in conf.env.libs:
+                        conf.env.libs["python"].append(arg)
+                        lsst.sconsUtils.log.info("Adding '%s' to target 'python'." % arg)
+                else:
+                    if os.path.isdir(arg):
+                        conf.env.AppendUnique(LIBPATH=[arg])
+                        lsst.sconsUtils.log.info("Adding '%s' to link path." % arg)
+        if conf.env['PLATFORM'] == 'darwin':
+            frameworkDir = libDir           # search up the libDir tree for the proper home for frameworks
+            while frameworkDir and not re.match("^//*$", frameworkDir):
+                frameworkDir, d2 = os.path.split(frameworkDir)
+                if d2 == "Python.framework":
+                    if not "Python" in os.listdir(os.path.join(frameworkDir, d2)):
+                        lsst.sconUtils.log.warn(
+                            "Expected to find Python in framework directory %s, but it isn't there"
+                            % frameworkDir
+                            )
+                        return False
+                    break
+            opt = "-F%s" % frameworkDir
+            if opt not in conf.env["LDMODULEFLAGS"]:
+                conf.env.Append(LDMODULEFLAGS = [opt,])
+        return True
+
+config = Configuration()

--- a/configs/starlink_ast.cfg
+++ b/configs/starlink_ast.cfg
@@ -1,0 +1,17 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+import subprocess
+
+dependencies = {}
+
+_astLibStr = subprocess.check_output("ast_link", shell=True).decode()
+# sconsUtils requires prerequisites first; ast_link gives them last
+astLibs = _astLibStr.split()
+astLibs.reverse()
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers = ["ast.h", "ast_err.h"],
+    libs = astLibs,
+)

--- a/configs/xpa.cfg
+++ b/configs/xpa.cfg
@@ -1,0 +1,13 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": [],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["xpa.h"],
+    libs=["xpa"],
+)

--- a/python/lsst/sconsUtils/dependencies.py
+++ b/python/lsst/sconsUtils/dependencies.py
@@ -13,7 +13,7 @@ from SCons.Script.SConscript import SConsEnvironment
 
 from . import installation
 from . import state
-from .utils import get_conda_prefix
+from .utils import get_conda_prefix, use_conda_compilers
 
 
 def configure(packageName, versionString=None, eupsProduct=None, eupsProductPath=None, noCfgFile=False):
@@ -79,8 +79,10 @@ def configure(packageName, versionString=None, eupsProduct=None, eupsProductPath
     state.env.doxygen = {"tags": [], "includes": []}
     state.env['CPPPATH'] = []
 
-    if 'SCONSUTILS_USE_CONDA_COMPILERS' in os.environ:
-        _conda_prefix = get_conda_prefix()
+    _conda_prefix = get_conda_prefix()
+    # _conda_prefix is usually around, even if not using conda compilers
+    if use_conda_compilers():
+        # if using the conda-force conda compilers, they handle rpath for us
         state.env['LIBPATH'] = ["%s/lib" % _conda_prefix]
     else:
         state.env['LIBPATH'] = []
@@ -90,8 +92,7 @@ def configure(packageName, versionString=None, eupsProduct=None, eupsProductPath
     # make scons a lot faster.
     state.env['XCPPPATH'] = []
 
-    if 'SCONSUTILS_USE_CONDA_COMPILERS' in os.environ:
-        _conda_prefix = get_conda_prefix()
+    if use_conda_compilers():
         state.env.Append(XCPPPATH=["%s/include" % _conda_prefix])
 
     # XCPPPPREFIX is a replacement for SCons' built-in INCPREFIX. It is used

--- a/python/lsst/sconsUtils/dependencies.py
+++ b/python/lsst/sconsUtils/dependencies.py
@@ -7,6 +7,7 @@ import os
 import os.path
 import collections
 import imp
+from sys import platform
 import SCons.Script
 from . import eupsForScons
 from SCons.Script.SConscript import SConsEnvironment
@@ -83,7 +84,12 @@ def configure(packageName, versionString=None, eupsProduct=None, eupsProductPath
     # _conda_prefix is usually around, even if not using conda compilers
     if use_conda_compilers():
         # if using the conda-force conda compilers, they handle rpath for us
-        state.env['LIBPATH'] = ["%s/lib" % _conda_prefix]
+        _conda_lib = f"{_conda_prefix}/lib"
+        state.env['LIBPATH'] = [_conda_lib]
+        if platform == "darwin":
+            state.env["_RPATH"] = f"-rpath {_conda_lib}"
+        else:
+            state.env.AppendUnique(RPATH=[_conda_lib])
     else:
         state.env['LIBPATH'] = []
 

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -20,7 +20,7 @@ import shlex
 import SCons.Script
 import SCons.Conftest
 from . import eupsForScons
-from .utils import get_conda_prefix
+from .utils import get_conda_prefix, use_conda_compilers
 
 SCons.Script.EnsureSConsVersion(2, 1, 0)
 
@@ -129,6 +129,7 @@ def _initEnvironment():
       TMP
       TMPDIR
       XPA_PORT
+      CONDA_BUILD_SYSROOT
     """.split()
 
     for key in preserveVars:
@@ -352,7 +353,7 @@ def _configureCommon():
     if env.GetOption("clean") or env.GetOption("no_exec") or env.GetOption("help"):
         env.whichCc = "unknown"         # who cares? We're cleaning/not execing, not building
     else:
-        if 'SCONSUTILS_USE_CONDA_COMPILERS' in os.environ:
+        if use_conda_compilers():
             # conda-build expects you to use the compilers as-is
             env['CC'] = os.environ['CC']
             env['CXX'] = os.environ['CXX']

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -142,6 +142,7 @@ def _initEnvironment():
         if not m:
             continue
         cfgPath.append(os.path.join(os.environ[k], "ups"))
+        cfgPath.append(os.path.join(os.environ[k], "configs"))
         if m.group("extra"):
             cfgPath.append(os.environ[k])
         else:

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -9,6 +9,7 @@ import sys
 import warnings
 import subprocess
 import platform
+from typing import Optional
 import SCons.Script
 
 
@@ -243,17 +244,22 @@ def memberOf(cls, name=None):
     return nested
 
 
-def get_conda_prefix():
-    """Returns a copy of the current conda prefix."""
+def get_conda_prefix() -> Optional[str]:
+    """Returns a copy of the current conda prefix, if available."""
+    _conda_prefix = os.environ.get('CONDA_PREFIX')
     if os.environ.get('CONDA_BUILD', "0") == "1":
         # when running conda-build, the right prefix to use is PREFIX
-        # however, this appears to not be around in some builds, so I
-        # am going to default back to CONDA_PREFIX
+        # however, this appears to be absent in some builds - but we
+        # already set the fallback
         if 'PREFIX' in os.environ:
             _conda_prefix = os.environ['PREFIX']
-        else:
-            _conda_prefix = os.environ['CONDA_PREFIX']
-    else:
-        # outside of conda-build, it is always CONDA_PREFIX
-        _conda_prefix = os.environ['CONDA_PREFIX']
     return _conda_prefix
+
+
+def use_conda_compilers():
+    """Returns True if we should use conda compilers"""
+    if "SCONSUTILS_USE_CONDA_COMPILERS" in os.environ:
+        return True
+    if "CONDA_BUILD_SYSROOT" in os.environ:
+        return True
+    return False

--- a/ups/sconsUtils.table
+++ b/ups/sconsUtils.table
@@ -1,2 +1,5 @@
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
+envPrepend(LD_LIBRARY_PATH, $HOME/anaconda3/envs/scipl/lib)
+envPrepend(DYLD_LIBRARY_PATH, $HOME/anaconda3/envs/scipl/lib)
+envPrepend(LSST_LIBRARY_PATH, $HOME/anaconda3/envs/scipl/lib)

--- a/ups/sconsUtils.table
+++ b/ups/sconsUtils.table
@@ -1,5 +1,2 @@
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
-envPrepend(LD_LIBRARY_PATH, $HOME/anaconda3/envs/scipl/lib)
-envPrepend(DYLD_LIBRARY_PATH, $HOME/anaconda3/envs/scipl/lib)
-envPrepend(LSST_LIBRARY_PATH, $HOME/anaconda3/envs/scipl/lib)

--- a/ups/sconsUtils.table
+++ b/ups/sconsUtils.table
@@ -1,7 +1,2 @@
-setupRequired(scons)
-setupRequired(pytest_flake8)
-setupRequired(pep8_naming)
-setupRequired(pytest_session2file)
-setupOptional(doxygen)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(PATH, ${PRODUCT_DIR}/bin)


### PR DESCRIPTION
This PR adds cfg files for third parties in the config directory.

It also contains logic to support those config files.

In addition, it has additional support for `CONDA_BUILD_SYSROOT` for the conda compilers, especially on macOS, and it will prefer using conda compilers if it encounters `CONDA_BUILD_SYSROOT`