### PR TITLE
DM-27696: Fix Boost deprecation warning in afw

### DIFF
--- a/configs/boost_timer.cfg
+++ b/configs/boost_timer.cfg
@@ -1,0 +1,14 @@
+# -*- python -*-
+
+import lsst.sconsUtils
+
+dependencies = {
+    "required": ["boost"],
+}
+
+config = lsst.sconsUtils.ExternalConfiguration(
+    __file__,
+    headers=["boost/timer/timer.hpp"],
+    libs={"main": [], "test": ["boost_timer"]},
+    eupsProduct="boost",
+)


### PR DESCRIPTION
This PR adds an entry for the compiled version of the Boost Timer library. Pipelines code previously used the header-only version of timer, but this is now deprecated.