### PR TITLE
DM-29139: Make test target depend on examples

### DIFF
--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -658,6 +658,7 @@ class BasicSConscript:
             state.env.Depends(pyTest, swigMods)
             state.env.Depends(pyTest, state.targets["python"])
             state.env.Depends(pyTest, state.targets["shebang"])
+            state.env.Depends(pyTest, state.targets["examples"])
         result = ccList + pyList
         state.targets["tests"].extend(result)
         return result


### PR DESCRIPTION
This usually won't matter but when examples involves compiled
code it is possible that the test collection phase will encounter
temporary files and fail internal consistency check.