### PR TITLE
DM-29139: Update ignore glob in pytest test collection to include *.tmp

### DIFF
--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -658,7 +658,6 @@ class BasicSConscript:
             state.env.Depends(pyTest, swigMods)
             state.env.Depends(pyTest, state.targets["python"])
             state.env.Depends(pyTest, state.targets["shebang"])
-            state.env.Depends(pyTest, state.targets["examples"])
         result = ccList + pyList
         state.targets["tests"].extend(result)
         return result

--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -341,6 +341,10 @@ class Control:
         # test collection
         interpreter += " --ignore=doc/html --ignore=doc/xml"
 
+        # Also include temporary files made by compilers.
+        # These can come from examples directories that include C++.
+        interpreter += " --ignore-glob='*.tmp'"
+
         target = os.path.join(self._tmpDir, "pytest-{}.xml".format(self._env['eupsProduct']))
 
         # Work out how many jobs scons has been configured to use


### PR DESCRIPTION
This reverses #85 and tries a different solution. The race condition always seems to involve .tmp files so target those explicitly.