### PR TITLE
DM-29563: move deployment platform to 10.13

### DIFF
--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -106,7 +106,7 @@ def _initVariables():
         ('baseversion', 'Specify the current base version', None),
         ('optFiles', "Specify a list of files that SHOULD be optimized", None),
         ('noOptFiles', "Specify a list of files that should NOT be optimized", None),
-        ('macosx_deployment_target', 'Deployment target for Mac OS X', '10.9'),
+        ('macosx_deployment_target', 'Deployment target for Mac OS X', '10.13'),
     )
 
 


### PR DESCRIPTION
deployment tools >= 10.13 are required for std::variant