### PR TITLE
DM-29563: add compilation flag_LIBCPP_DISABLE_AVAILABILITY=1 to allow use of st…

### DIFF
--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -192,6 +192,11 @@ def _initEnvironment():
         # We want to be explicit about the OS X version we're targeting
         #
         env['ENV']['MACOSX_DEPLOYMENT_TARGET'] = env['macosx_deployment_target']
+        # This flag is required for std::variant and std::filesystem
+        # on deployment platforms < 10.13 and 10.15
+        for flag in ("-D_LIBCPP_DISABLE_AVAILABILITY=1", ):
+            env["CFLAGS"].append(flag)
+            env["CXXFLAGS"].append(flag)
         log.info("Setting OS X binary compatibility level: %s" % env['ENV']['MACOSX_DEPLOYMENT_TARGET'])
         #
         # For XCode 7.3 we need to explicitly add a trailing slash to library


### PR DESCRIPTION
…d::variant/filesystem on pre 10.13 or 10.15 macos deployment platforms