### PR TITLE
REF detect conda compilers by looking for conda build too

### DIFF
--- a/doc/lsst.sconsUtils/index.rst
+++ b/doc/lsst.sconsUtils/index.rst
@@ -46,10 +46,10 @@ Python API reference
    :no-main-docstr:
    :no-inheritance-diagram:
 
-Using ``sconsUtils`` with the ``conda`` Compilers
-=================================================
+Using ``sconsUtils`` without the ``conda`` Compilers
+====================================================
 
-If you would like to use ``sconsUtils`` with the ``conda`` compilers, then put
-``SCONSUTILS_USE_CONDA_COMPILERS`` in your environment with a non-``None`` value.
-This environment variable will instruct ``sconsUtils`` to use the compiler
-flags and compilers from the enclosing ``conda`` environment.
+If you would like to use ``sconsUtils`` without the ``conda`` compilers, then put
+``SCONSUTILS_AVOID_CONDA_COMPILERS`` in your environment with a non-``None`` value.
+This environment variable will instruct ``sconsUtils`` to use the defualt system 
+compiler flags and compilers.

--- a/doc/lsst.sconsUtils/index.rst
+++ b/doc/lsst.sconsUtils/index.rst
@@ -51,5 +51,5 @@ Using ``sconsUtils`` without the ``conda`` Compilers
 
 If you would like to use ``sconsUtils`` without the ``conda`` compilers, then put
 ``SCONSUTILS_AVOID_CONDA_COMPILERS`` in your environment with a non-``None`` value.
-This environment variable will instruct ``sconsUtils`` to use the defualt system 
-compiler flags and compilers.
+This environment variable will instruct ``sconsUtils`` to use the default system 
+compilers and compiler flags.

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -130,6 +130,7 @@ def _initEnvironment():
       TMPDIR
       XPA_PORT
       CONDA_BUILD_SYSROOT
+      SDKROOT
     """.split()
 
     for key in preserveVars:
@@ -205,7 +206,7 @@ def _initEnvironment():
         #
         env['LIBDIRSUFFIX'] = '/'
 
-    if 'SCONSUTILS_USE_CONDA_COMPILERS' in os.environ:
+    if use_conda_compilers():
         _conda_prefix = get_conda_prefix()
         LDFLAGS = shlex.split(os.environ['LDFLAGS'])  # respects quoting!
         LDFLAGS = [v for v in LDFLAGS if v[0:2] != '-L']

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -261,7 +261,7 @@ def use_conda_compilers():
     if "SCONSUTILS_AVOID_CONDA_COMPILERS" in os.environ:
         return False
     if "CONDA_BUILD_SYSROOT" in os.environ or "CONDA_PREFIX" in os.environ:
-        True
+        return True
     if os.environ.get('CONDA_BUILD', "0") == "1":
         return True
     return False

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -258,9 +258,9 @@ def get_conda_prefix() -> Optional[str]:
 
 def use_conda_compilers():
     """Returns True if we should use conda compilers"""
-    if "SCONSUTILS_USE_CONDA_COMPILERS" in os.environ:
-        return True
-    if "CONDA_BUILD_SYSROOT" in os.environ:
+    if "SCONSUTILS_AVOID_CONDA_COMPILERS" in os.environ:
+        return False
+    if "CONDA_BUILD_SYSROOT" in os.environ or "CONDA_PREFIX" in os.environ:
         True
     if os.environ.get('CONDA_BUILD', "0") == "1":
         return True

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -260,6 +260,6 @@ def use_conda_compilers():
     """Returns True if we should use conda compilers"""
     if "SCONSUTILS_USE_CONDA_COMPILERS" in os.environ:
         return True
-    if "CONDA_BUILD_SYSROOT" in os.environ:
+    if os.environ.get('CONDA_BUILD', "0") == "1":
         return True
     return False

--- a/python/lsst/sconsUtils/utils.py
+++ b/python/lsst/sconsUtils/utils.py
@@ -260,6 +260,8 @@ def use_conda_compilers():
     """Returns True if we should use conda compilers"""
     if "SCONSUTILS_USE_CONDA_COMPILERS" in os.environ:
         return True
+    if "CONDA_BUILD_SYSROOT" in os.environ:
+        True
     if os.environ.get('CONDA_BUILD', "0") == "1":
         return True
     return False


### PR DESCRIPTION
This PR detects conda build via the standard env var instead of depending on the sysroot variable.