### PR TITLE
DM-24719: Change normal EUPS log to info from warn.

### DIFF
--- a/python/lsst/sconsUtils/dependencies.py
+++ b/python/lsst/sconsUtils/dependencies.py
@@ -229,7 +229,7 @@ class Configuration:
         if version is not None:
             self.version = version
         if productDir is None:
-            state.log.warn("Could not find EUPS product dir for '%s'; using %s."
+            state.log.info("Could not find EUPS product dir for '%s'; using %s."
                            % (self.eupsProduct, self.root))
         else:
             self.root = os.path.realpath(productDir)


### PR DESCRIPTION
The `info` message will only be displayed if the `--verbose` flag is used in the sconsUtils custom logger.  This gives the desired result that the message is typically suppressed unless the user asks for verbose output.