### PR TITLE
DM-33727: Ensure that pytest uses a local configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@ max-line-length = 110
 max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N816, W503
 exclude = __init__.py, tests/.tests
+
+[tool:pytest]
+addopts = --flake8
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W503
+


### PR DESCRIPTION
Otherwise it may walk up the directory tree looking for a pytest.ini.

Fixes #100 

Alternative to #101 