### PR TITLE
Add GCC_COLORS to preserved envvars

### DIFF
--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -131,6 +131,7 @@ def _initEnvironment():
       XPA_PORT
       CONDA_BUILD_SYSROOT
       SDKROOT
+      GCC_COLORS
     """.split()
 
     codeCheckerVars = """


### PR DESCRIPTION
GCC_COLORS is used to colorize the gcc output and changing it can be useful
because some of the defaults may be hard to read on certain terminals.