### PR TITLE
DM-12659: Clean up Doxygen tagfile imports

### DIFF
--- a/ups/sconsUtils.cfg
+++ b/ups/sconsUtils.cfg
@@ -4,4 +4,4 @@ from lsst.sconsUtils import Configuration
 
 dependencies = {}
 
-config = Configuration(__file__, libs=[], hasSwigFiles=False)
+config = Configuration(__file__, libs=[], hasSwigFiles=False, hasDoxygenTag=False)


### PR DESCRIPTION
This PR stops any package that imports `sconsUtils` from expecting a Doxygen tag file.