### PR TITLE
DM-36237: Pass through http proxy variables to tests.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install -y -q \
-            flake8 \
+            "flake8<5" \
             pytest pytest-flake8 pytest-xdist pytest-openfiles pytest-cov pytest-session2file
 
       - name: List installed packages

--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -94,7 +94,7 @@ class Control:
                                "astropy due to lack of astropy directory within it")
 
         # Forward some environment to the tests
-        for envvar in ["PYTHONPATH", xdgCacheVar]:
+        for envvar in ["PYTHONPATH", "HTTP_PROXY", "HTTPS_PROXY", xdgCacheVar]:
             if envvar in os.environ:
                 env.AppendENVPath(envvar, os.environ[envvar])
 


### PR DESCRIPTION
This allows scons tests to run on USDF and other locations that need proxies to connect to the internet for tests that it (including anything with astropy.time).