### PR TITLE
DM-42999: Enable Boost Timer version 2 in production code

### DIFF
--- a/configs/boost_timer.cfg
+++ b/configs/boost_timer.cfg
@@ -9,6 +9,6 @@ dependencies = {
 config = lsst.sconsUtils.ExternalConfiguration(
     __file__,
     headers=["boost/timer/timer.hpp"],
-    libs={"main": [], "test": ["boost_timer"]},
+    libs=["boost_timer"],
     eupsProduct="boost",
 )


### PR DESCRIPTION
This PR allows the compiled library from [Boost Timer](https://www.boost.org/doc/libs/1_84_0/libs/timer/doc/index.html) 2 to be used in production code, not just test code (version 1 of the library was header-only). It must be merged before lsst/ip_diffim#298. 