### PR TITLE
DM-47069: Follow links when walking the directory tree during installation

### DIFF
--- a/python/lsst/sconsUtils/installation.py
+++ b/python/lsst/sconsUtils/installation.py
@@ -307,7 +307,7 @@ class DirectoryInstaller:
         if not os.path.isdir(destpath):
             state.log.info(f"Creating directory {destpath}")
             os.makedirs(destpath)
-        for root, dirnames, filenames in os.walk(source[0].path):
+        for root, dirnames, filenames in os.walk(source[0].path, followlinks=True):
             if not self.recursive:
                 dirnames[:] = []
             else:


### PR DESCRIPTION
This enables support for symlinking within the Python source tree in order to point to directories containing installable resources.

The ticket is about updating the sdm_schemas EUPS installation, where it was found that using these types of links lead to resource files not being installed, as `walk` will skip these links by default.