### PR TITLE
DM-42226: Write python package metadata

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        pyversion: ["3.10", "3.11", "3.12"]
+        pyversion: ["3.11", "3.12", "3.13"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install -y -q \
-            pytest pytest-xdist pytest-openfiles pytest-cov pytest-session2file
+            pytest pytest-xdist pytest-cov pytest-session2file
 
       - name: List installed packages
         shell: bash -l {0}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,7 @@ jobs:
         run: |
           setup -k -r .
           scons -j2
+          python -c 'import importlib.metadata as M; print(M.version("lsst.sconsUtils"))'
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,12 +15,11 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.pyversion }}
-          auto-update-conda: true
           channels: conda-forge,defaults
           miniforge-variant: Miniforge3
           use-mamba: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,7 @@ jobs:
           scons -j2
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
-          file: tests/.tests/pytest-sconsUtils.xml-cov-sconsUtils.xml
+          files: tests/.tests/pytest-sconsUtils.xml-cov-sconsUtils.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ tests/.tests
 tests/testFailedTests/python
 tests/testFailedTests/tests/.tests
 .coverage
+python/*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ tests/.tests
 tests/testFailedTests/python
 tests/testFailedTests/tests/.tests
 .coverage
-python/*.egg-info/
+python/*.dist-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.10.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -24,6 +24,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.3.3
+    rev: v0.8.0
     hooks:
       - id: ruff

--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -654,12 +654,12 @@ def PackageInfo(self, pythonDir, versionString=None):
         pythonPackageName = "lsst_" + state.env["packageName"]
     else:
         pythonPackageName = state.env["packageName"]
-    eggDir = os.path.join(pythonDir, f"{pythonPackageName}.egg-info")
-    filename = os.path.join(eggDir, "PKG-INFO")
+    eggDir = os.path.join(pythonDir, f"{pythonPackageName}.dist-info")
+    filename = os.path.join(eggDir, "METADATA")
     oldMd5 = _calcMd5(filename)
 
-    def makePackageInfo(target, source, env):
-        # Create the PKG-INFo metadata.
+    def makePackageMetadata(target, source, env):
+        # Create the metadata file.
         try:
             version = determineVersion(state.env, versionString)
         except RuntimeError:
@@ -675,7 +675,9 @@ def PackageInfo(self, pythonDir, versionString=None):
             state.log.info(f'PackageInfo(["{target[0]}"], [])')
 
     results = []
-    results.append(self.Command(filename, [], self.Action(makePackageInfo, strfunction=lambda *args: None)))
+    results.append(
+        self.Command(filename, [], self.Action(makePackageMetadata, strfunction=lambda *args: None))
+    )
 
     # Create the entry points file if defined in the pyproject.toml file.
     entryPoints = {}

--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -55,7 +55,6 @@ class BasicSConstruct:
         noCfgFile=False,
         sconscriptOrder=None,
         disableCc=False,
-        metadataName="python/lsst_%s.egg-info/PKG-INFO",
     ):
         cls.initialize(
             packageName,
@@ -67,7 +66,6 @@ class BasicSConstruct:
             noCfgFile=noCfgFile,
             sconscriptOrder=sconscriptOrder,
             disableCc=disableCc,
-            metadataName=metadataName,
         )
         cls.finish(defaultTargets, subDirList, ignoreRegex)
         return state.env
@@ -84,7 +82,6 @@ class BasicSConstruct:
         noCfgFile=False,
         sconscriptOrder=None,
         disableCc=False,
-        metadataName="python/lsst_%s.egg-info/PKG-INFO",
     ):
         """Convenience function to replace standard SConstruct boilerplate
         (step 1).
@@ -132,10 +129,6 @@ class BasicSConstruct:
             allows a faster startup and permits building on systems that don't
             meet the requirements for the C++ compilter (e.g., for
             pure-python packages).
-        metadataName : `str`, optional
-            If non-None, builds a ``PKG-INFO`` file containing the version
-            information and, potentially, other derived metadata files in the
-            same directory.
 
         Returns
         -------
@@ -159,12 +152,10 @@ class BasicSConstruct:
             except TypeError:
                 pass
             state.targets["version"] = state.env.VersionModule(versionModuleName)
-        if metadataName is not None:
-            try:
-                metadataName = metadataName % packageName
-            except TypeError:
-                pass
-            state.targets["pkginfo"] = state.env.PackageInfo(metadataName)
+        # Always attempt to write python package info into the python
+        # directory.
+        if os.path.exists("python"):
+            state.targets["pkginfo"] = state.env.PackageInfo("python")
         scripts = []
         for root, dirs, files in os.walk("."):
             if "SConstruct" in files and root != ".":

--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -127,7 +127,7 @@ class BasicSConstruct:
         disableCC : `bool`, optional
             Should the C++ compiler check be disabled? Disabling this checks
             allows a faster startup and permits building on systems that don't
-            meet the requirements for the C++ compilter (e.g., for
+            meet the requirements for the C++ compiler (e.g., for
             pure-python packages).
 
         Returns

--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -145,7 +145,7 @@ class BasicSConstruct:
         state.env.BuildETags()
         if cleanExt is None:
             cleanExt = r"*~ core core.[1-9]* *.so *.os *.o *.pyc *.pkgc"
-        state.env.CleanTree(cleanExt, "__pycache__ .pytest_cache")
+        state.env.CleanTree(cleanExt, "__pycache__ .pytest_cache *.dist-info")
         if versionModuleName is not None:
             try:
                 versionModuleName = versionModuleName % "/".join(packageName.split("_"))

--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -55,6 +55,7 @@ class BasicSConstruct:
         noCfgFile=False,
         sconscriptOrder=None,
         disableCc=False,
+        metadataName="python/lsst_%s.egg-info/PKG-INFO",
     ):
         cls.initialize(
             packageName,
@@ -66,6 +67,7 @@ class BasicSConstruct:
             noCfgFile=noCfgFile,
             sconscriptOrder=sconscriptOrder,
             disableCc=disableCc,
+            metadataName=metadataName,
         )
         cls.finish(defaultTargets, subDirList, ignoreRegex)
         return state.env
@@ -82,6 +84,7 @@ class BasicSConstruct:
         noCfgFile=False,
         sconscriptOrder=None,
         disableCc=False,
+        metadataName="python/lsst_%s.egg-info/PKG-INFO",
     ):
         """Convenience function to replace standard SConstruct boilerplate
         (step 1).
@@ -129,6 +132,10 @@ class BasicSConstruct:
             allows a faster startup and permits building on systems that don't
             meet the requirements for the C++ compilter (e.g., for
             pure-python packages).
+        metadataName : `str`, optional
+            If non-None, builds a ``PKG-INFO`` file containing the version
+            information and, potentially, other derived metadata files in the
+            same directory.
 
         Returns
         -------
@@ -152,6 +159,12 @@ class BasicSConstruct:
             except TypeError:
                 pass
             state.targets["version"] = state.env.VersionModule(versionModuleName)
+        if metadataName is not None:
+            try:
+                metadataName = metadataName % packageName
+            except TypeError:
+                pass
+            state.targets["pkginfo"] = state.env.PackageInfo(metadataName)
         scripts = []
         for root, dirs, files in os.walk("."):
             if "SConstruct" in files and root != ".":
@@ -233,6 +246,8 @@ class BasicSConstruct:
         )
         if "version" in state.targets:
             state.env.Default(state.targets["version"])
+        if "pkginfo" in state.targets:
+            state.env.Default(state.targets["pkginfo"])
         state.env.Requires(state.targets["tests"], state.targets["version"])
         state.env.Decider("MD5-timestamp")  # if timestamps haven't changed, don't do MD5 checks
         #

--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -156,6 +156,9 @@ class BasicSConstruct:
         # directory.
         if os.path.exists("python"):
             state.targets["pkginfo"] = state.env.PackageInfo("python")
+        # Python script generation does no harm since it will only do anything
+        # if there is a scripts entry in pyproject.toml.
+        state.targets["scripts"] = state.env.PythonScripts()
         scripts = []
         for root, dirs, files in os.walk("."):
             if "SConstruct" in files and root != ".":
@@ -237,9 +240,14 @@ class BasicSConstruct:
         )
         if "version" in state.targets:
             state.env.Default(state.targets["version"])
+            state.env.Requires(state.targets["tests"], state.targets["version"])
         if "pkginfo" in state.targets:
             state.env.Default(state.targets["pkginfo"])
-        state.env.Requires(state.targets["tests"], state.targets["version"])
+            state.env.Requires(state.targets["tests"], state.targets["pkginfo"])
+        if "scripts" in state.targets:
+            state.env.Default(state.targets["scripts"])
+            state.env.Requires(state.targets["tests"], state.targets["scripts"])
+
         state.env.Decider("MD5-timestamp")  # if timestamps haven't changed, don't do MD5 checks
         #
         # Check if any of the tests failed by looking for *.failed files.

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -50,6 +50,7 @@ targets = {
     "version": [],
     "shebang": [],
     "pkginfo": [],
+    "scripts": [],
 }
 
 env = None

--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -49,6 +49,7 @@ targets = {
     "include": [],
     "version": [],
     "shebang": [],
+    "pkginfo": [],
 }
 
 env = None


### PR DESCRIPTION
This writes an egg-info directory into the python directory, enabling entry points and importlib.metadata to function using standard Python interfaces.