### PR TITLE
DM-48284: Write RECORD and INSTALLER files to dist-info directory

### DIFF
--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -695,6 +695,15 @@ def PackageInfo(self, pythonDir, versionString=None):
         self.Command(filename, [], self.Action(makePackageMetadata, strfunction=lambda *args: None))
     )
 
+    def makeInstallerFile(target, source, env):
+        # Write the INSTALLER file. This is purely something to potentially
+        # tell the end user the tooling that was used to install the files.
+        with open(target[0].abspath, "w") as outFile:
+            print("sconsUtils", file=outFile)
+
+    filename = os.path.join(distDir, "INSTALLER")
+    results.append(self.Command(filename, [], self.Action(makeInstallerFile, strfunction=lambda *args: None)))
+
     # Create the entry points file if defined in the pyproject.toml file.
     entryPoints = toml_project.get("entry-points", {})
     if entryPoints:

--- a/python/lsst/sconsUtils/scripts.py
+++ b/python/lsst/sconsUtils/scripts.py
@@ -243,6 +243,7 @@ class BasicSConstruct:
             state.env.Requires(state.targets["tests"], state.targets["version"])
         if "pkginfo" in state.targets:
             state.env.Default(state.targets["pkginfo"])
+            state.env.Requires(state.targets["pkginfo"], state.targets["python"])
             state.env.Requires(state.targets["tests"], state.targets["pkginfo"])
         if "scripts" in state.targets:
             state.env.Default(state.targets["scripts"])


### PR DESCRIPTION
The RECORD file allows packages_distributions to correctly find the sconsUtils packages.