### PR TITLE
DM-48776: Choose shebang rewriting for pyproject scripts to match shebang target

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -18,12 +18,12 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.0
+    rev: v0.9.4
     hooks:
       - id: ruff

--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -1,4 +1,5 @@
-"""Extra builders and methods to be injected into the SConsEnvironment class.
+"""Extra builders and methods to be injected into the SConsEnvironment
+class.
 """
 
 __all__ = ("filesToTag", "DoxygenBuilder")

--- a/python/lsst/sconsUtils/builders.py
+++ b/python/lsst/sconsUtils/builders.py
@@ -15,7 +15,7 @@ from SCons.Script.SConscript import SConsEnvironment
 
 from . import state
 from .installation import determineVersion, getFingerprint
-from .utils import memberOf, whichPython
+from .utils import memberOf, needShebangRewrite, whichPython
 
 
 @memberOf(SConsEnvironment)
@@ -805,11 +805,17 @@ def PythonScripts(self):
             return
         os.makedirs(os.path.dirname(cmdfile), exist_ok=True)
         package, func = scripts[command].split(":", maxsplit=1)
+        python_exe = whichPython()
+        if needShebangRewrite():
+            shebang = python_exe
+        else:
+            # Linux has very small shebang limit so always use env.
+            shebang = f"/usr/bin/env {os.path.basename(python_exe)}"
         with open(cmdfile, "w") as fd:
             # Follow setuptools convention and always change the shebang.
             # Can not add noqa on Linux for long paths so do not add anywhere.
             print(
-                rf"""#!{whichPython()}
+                rf"""#!{shebang}
 import sys
 from {package} import {func}
 if __name__ == '__main__':

--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -1,5 +1,4 @@
-"""Control which tests run, and how.
-"""
+"""Control which tests run, and how."""
 
 __all__ = ("Control",)
 


### PR DESCRIPTION
Remember that linux has a very small (127) character shebang limit and /usr/bin/env should be used all the time except for cases where SIP is involved on macOS.