### PR TITLE
DM-48797: Always forward environment variables needed for scripts

### DIFF
--- a/python/lsst/sconsUtils/state.py
+++ b/python/lsst/sconsUtils/state.py
@@ -426,6 +426,13 @@ def _initEnvironment():
     #
     env["eupsFlavor"] = eupsForScons.flavor()
 
+    # Forward environment variables that should always be set to allow
+    # our code to run even outside of tests. Executables would normally
+    # pick up the linker environment variables via libraryLoaderEnvironment().
+    for envvar in ["PYTHONPATH", "HTTP_PROXY", "HTTPS_PROXY"]:
+        if envvar in os.environ:
+            env.AppendENVPath(envvar, os.environ[envvar])
+
 
 _configured = False
 

--- a/python/lsst/sconsUtils/tests.py
+++ b/python/lsst/sconsUtils/tests.py
@@ -94,8 +94,8 @@ class Control:
                     "astropy due to lack of astropy directory within it"
                 )
 
-        # Forward some environment to the tests
-        for envvar in ["PYTHONPATH", "HTTP_PROXY", "HTTPS_PROXY", xdgCacheVar]:
+        # Forward additional environment to the tests.
+        for envvar in [xdgCacheVar]:
             if envvar in os.environ:
                 env.AppendENVPath(envvar, os.environ[envvar])
 


### PR DESCRIPTION
Previously these were only forwarded when running tests.